### PR TITLE
Send author_name instead of author_id down the wire as post_author

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -270,6 +270,8 @@ function hookpress_generic_action($id,$args) {
 			case 'POST':
 			case 'ATTACHMENT':
 				$newobj = get_post($arg,ARRAY_A);
+				
+				$newobj["post_author"] = get_the_author_meta('display_name', $newobj["post_author"]);
 
 				if ($arg_names[$i] == 'POST')
 					$newobj["post_url"] = get_permalink($newobj["ID"]);


### PR DESCRIPTION
When receiving webhooks for posted comments the author's display name is given as `comment_author`. In contrast to this behavior only an `author_id` is given for posts as `post_author`. 