### PR TITLE
Replace `split` and `ereg`

### DIFF
--- a/includes.php
+++ b/includes.php
@@ -97,7 +97,7 @@ if ($desc['type'] == 'filter')
 		
 	$fields = array();
 	foreach ($args as $arg) {
-		if (ereg('[A-Z]+',$arg))
+		if (preg_match('/[A-Z]+/',$arg))
 			$fields = array_merge($fields,hookpress_get_fields($arg));
 		else
 			$fields[] = $arg;

--- a/services.php
+++ b/services.php
@@ -46,7 +46,7 @@ function hookpress_ajax_add_fields() {
 			'type'=>$_POST['type'],
 			'hook'=>$_POST['hook'],
 			'enabled'=>$_POST['enabled'],
-			'fields'=>split(',',$_POST['fields'])
+			'fields'=>explode(',',$_POST['fields'])
 		);
 		hookpress_update_hook( $id, $edithook );
 
@@ -57,7 +57,7 @@ function hookpress_ajax_add_fields() {
 			'url'=>$_POST['url'],
 			'type'=>$_POST['type'],
 			'hook'=>$_POST['hook'],
-			'fields'=>split(',',$_POST['fields']),
+			'fields'=>explode(',',$_POST['fields']),
 			'enabled'=>true
 		);
 		$id = hookpress_add_hook($newhook);

--- a/services.php
+++ b/services.php
@@ -10,7 +10,7 @@ function hookpress_ajax_get_fields() {
 	$fields = array();
 	if (is_array($args)) {
 		foreach ($args as $arg) {
-			if (ereg('[A-Z]+',$arg))
+			if (preg_match('/[A-Z]+/',$arg))
 				$fields = array_merge($fields,hookpress_get_fields($arg));
 			else
 				$fields[] = $arg;


### PR DESCRIPTION
This replaces instances of `split` with `explode` and instances of `ereg` with `preg_match`. Both `split` and `explode` were deprecated in PHP 5.3.0 and completely removed in PHP 7.0.0. There is another active pull request that does something similar but only replaces one instance of `ereg`.