### PR TITLE
PHP7 support - changed 'ereg'->'preg_match' & 'split'->'explode'

### DIFF
--- a/hookpress.php
+++ b/hookpress.php
@@ -21,9 +21,9 @@ function hookpress_init() {
 		update_option('hookpress_version',$hookpress_version);
 
 	add_action('admin_menu', 'hookpress_config_page');
+	hookpress_register_hooks();
 }
 add_action('init', 'hookpress_init');
-hookpress_register_hooks();
 
 // register ajax service
 add_action('wp_ajax_hookpress_get_fields', 'hookpress_ajax_get_fields');

--- a/includes.php
+++ b/includes.php
@@ -30,10 +30,15 @@ function hookpress_get_fields( $type ) {
 	if ($type == 'POST' || $type == 'PARENT_POST') {
 
 		$fields[] = 'post_url';
+		$fields[] = 'featured_image_src';
+		$fields[] = 'featured_image_width';
+		$fields[] = 'featured_image_height';
+		$fields[] = 'featured_image_sizes';
 
 		$meta_keys = $wpdb->get_col("select distinct(meta_key) from $wpdb->postmeta");
 
 		$fields = array_merge($fields, $meta_keys);
+
 	}
 
 	if ($type == 'PARENT_POST')
@@ -293,6 +298,20 @@ function hookpress_generic_action($id,$args) {
 
 					$meta = get_post_meta($newobj["ID"], '', true);
 					$newobj = array_merge($meta, $newobj);
+
+					$f_im_data = get_the_post_thumbnail($newobj["ID"]);
+					$ex = [];
+					preg_match_all("/([a-z]+)=\"([a-z0-9A-Z_\-\.\/:]+)\"/", $f_im_data, $ex);
+					foreach ($ex[1] as $key => $value) {
+						if ( array_search("featured_image_{$value}",$desc['fields']) ) {
+							error_log(">>>> featured_image_{$value}");
+							$newobj["featured_image_{$value}"] = $ex[ 2 ][ $key ];
+						}
+						unset($key,$value);
+					}
+					error_log(print_r($desc['fields'],true));
+					error_log(print_r($ex[1],true));
+					unset($f_im_data,$ex);
 				}
 
 				if (wp_is_post_revision($arg)) {

--- a/includes.php
+++ b/includes.php
@@ -27,14 +27,22 @@ function hookpress_get_fields( $type ) {
 	}
 
 	// if it's a POST, we have a URL for it as well.
-	if ($type == 'POST' || $type == 'PARENT_POST')
+	if ($type == 'POST' || $type == 'PARENT_POST') {
+
 		$fields[] = 'post_url';
+
+		$meta_keys = $wpdb->get_col("select distinct(meta_key) from $wpdb->postmeta");
+
+		$fields = array_merge($fields, $meta_keys);
+	}
 
 	if ($type == 'PARENT_POST')
 		$fields = array_map(create_function('$x','return "parent_$x";'),$fields);
 
 	if ($type == 'OLD_USER_OBJ')
 		$fields = array_map(create_function('$x','return "old_$x";'),$fields);
+
+	$fields = apply_filters('hookpress_get_fields', $fields, $type);
 
 	return array_unique($fields);
 }
@@ -43,12 +51,14 @@ function hookpress_print_edit_webhook( $id ){
 ?>
 <?php
 	global $wpdb, $hookpress_actions, $hookpress_filters;
-	
+
 	$webhooks = hookpress_get_hooks( );
 	$desc = $webhooks[$id];
-		
-	if ($desc['type'] == 'action')
-		$hooks = array_keys($hookpress_actions);	
+
+	if ($desc['type'] == 'action') {
+		$actions = apply_filters( 'hookpress_actions', $hookpress_actions );
+		$hooks = array_keys($actions);
+	}
 	if ($desc['type'] == 'filter')
 		$hooks = array_keys($hookpress_filters);
 ?>
@@ -58,27 +68,27 @@ function hookpress_print_edit_webhook( $id ){
 <input type="hidden" name="enabled" id="enabled" value="<?php echo $desc['enabled']; ?>" />
 <table>
 <tr><td><label style='font-weight: bold' for='edithook'><?php _e("WordPress hook type",'hookpress');?>: </label></td>
-<td><input type='radio' id='action' class='newtype' name='newtype' <?php checked('action',$desc['type']);?>> <?php _e("action","hookpress");?></input> 
+<td><input type='radio' id='action' class='newtype' name='newtype' <?php checked('action',$desc['type']);?>> <?php _e("action","hookpress");?></input>
 <input type='radio' id='filter' class='newtype' name='newtype' <?php checked('filter',$desc['type']);?>> <?php _e("filter","hookpress");?></input></td></tr>
 <tr>
 <td><label style='font-weight: bold' for='edithook' id='action_or_filter'>
 <?php
-if ($desc['type'] == 'action')
-	echo 'Action:';
-if ($desc['type'] == 'filter')
-	echo 'Filter:';
+	if ($desc['type'] == 'action')
+		echo 'Action:';
+	if ($desc['type'] == 'filter')
+		echo 'Filter:';
 ?>
 </label></td>
 <td><select name='edithook' id='edithook'>
-		<?php		
-			sort($hooks);
-			foreach ($hooks as $hook) {
-				$selected = ($hook == $desc['hook'])?'selected="true"':'';
+		<?php
+	sort($hooks);
+	foreach ($hooks as $hook) {
+		$selected = ($hook == $desc['hook'])?'selected="true"':'';
 		$hook = esc_html( $hook );
-				echo "<option value='$hook' $selected>$hook</option>";
-			}
-			$nonce_submit = "<input type='hidden' id='submit-nonce' name='submit-nonce' value='" . wp_create_nonce( 'submit-webhook') . "' />";
-		?>
+		echo "<option value='$hook' $selected>$hook</option>";
+	}
+	$nonce_submit = "<input type='hidden' id='submit-nonce' name='submit-nonce' value='" . wp_create_nonce( 'submit-webhook') . "' />";
+        ?>
 	</select></td></tr>
 <tr><td style='vertical-align: top'><label style='font-weight: bold' for='editfields'><?php _e("Fields",'hookpress');?>: </label>
 <br/>
@@ -90,11 +100,13 @@ if ($desc['type'] == 'filter')
 <select style='vertical-align: top' name='editfields' id='editfields' multiple='multiple' size='8'>
 <?php
 	global $wpdb, $hookpress_actions, $hookpress_filters;
-	if ($desc['type'] == 'action')
-		$args = $hookpress_actions[$desc['hook']];
+	if ($desc['type'] == 'action') {
+		$hooks = apply_filters( 'hookpress_actions', $hookpress_actions );
+		$args = $hooks[$desc['hook']];
+	}
 	if ($desc['type'] == 'filter')
 		$args = $hookpress_filters[$desc['hook']];
-		
+
 	$fields = array();
 	foreach ($args as $arg) {
 		if (preg_match('/[A-Z]+/',$arg))
@@ -102,7 +114,7 @@ if ($desc['type'] == 'filter')
 		else
 			$fields[] = $arg;
 	}
-	
+
 	if ($desc['type'] == 'filter') {
 		$first = array_shift($fields);
 		$first = esc_html( $first );
@@ -116,7 +128,7 @@ if ($desc['type'] == 'filter')
 				$selected = 'selected="true"';
 			}
 		}
-	$field = esc_html( $field );
+		$field = esc_html( $field );
 		echo "<option value='$field' $selected>$field</option>";
 	}
 	$desc['url'] = esc_html( $desc['url'] );
@@ -135,40 +147,40 @@ if ($desc['type'] == 'filter')
 }
 
 function hookpress_print_webhook_row( $id ) {
-#	$webhooks = get_option('hookpress_webhooks');
+	#	$webhooks = get_option('hookpress_webhooks');
 	$webhooks = hookpress_get_hooks( );
 	$desc = $webhooks[$id];
 
 	if( !empty( $desc ) ):
-	
-	$is_active = $desc['enabled'];
-	$html_safe['id'] = esc_html( $id );
 
-	if ( $is_active ) :
-		$nonce_action = "<input type='hidden' id='action-nonce-{$html_safe['id']}' name='action-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'deactivate-webhook-' . $html_safe['id'] ) . "' />";
-		$action = '<a href="#" id="on'. $html_safe['id'] . '" title="' . __('Deactivate this webhook') . '" class="on">' . __('Deactivate') . '</a>';
-	else :
-		$nonce_action = "<input type='hidden' id='action-nonce-{$html_safe['id']}' name='action-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'activate-webhook-' . $html_safe['id'] ) . "' />";
-#		$action = '<a href="#'. $nonce_action . '" id="off'. $html_safe['id'] . '" title="' . __('Activate this webhook') . '" class="off">' . __('Activate') . '</a>';
-		$action = '<a href="#" id="off'. $html_safe['id'] . '" title="' . __('Activate this webhook') . '" class="off">' . __('Activate') . '</a>';
-	endif;
+		$is_active = $desc['enabled'];
+		$html_safe['id'] = esc_html( $id );
 
-	$nonce_delete = "<input type='hidden' id='delete-nonce-{$html_safe['id']}' name='delete-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'delete-webhook-' . $html_safe['id'] ) . "' />";
-	$delete = '<a href="#" id="delete'. $html_safe['id'] . '" title="' . __('Delete this webhook') . '" class="delete">' . __('Delete') . '</a>';
-	if( count( $desc['fields'] ) > 1 ) {
-		$desc['fields'] = array_map( 'esc_html', $desc['fields'] );
-		$fields = implode('</code>, <code>', $desc['fields'] );
-	} else
-		$fields = esc_html( $desc['fields'][0] );
-		
-	$edit = '<a href="#TB_inline?inlineId=hookpress-webhook&height=330&width=500" id="edit'. $html_safe['id'] . '" title="' . __('Edit this webhook') . '" class="thickbox edit">' . __('Edit') . '</a>';
-	
-	$activeornot = $desc['enabled'] ? 'active' : 'inactive';
+		if ( $is_active ) :
+			$nonce_action = "<input type='hidden' id='action-nonce-{$html_safe['id']}' name='action-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'deactivate-webhook-' . $html_safe['id'] ) . "' />";
+			$action = '<a href="#" id="on'. $html_safe['id'] . '" title="' . __('Deactivate this webhook') . '" class="on">' . __('Deactivate') . '</a>';
+		else :
+			$nonce_action = "<input type='hidden' id='action-nonce-{$html_safe['id']}' name='action-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'activate-webhook-' . $html_safe['id'] ) . "' />";
+			#		$action = '<a href="#'. $nonce_action . '" id="off'. $html_safe['id'] . '" title="' . __('Activate this webhook') . '" class="off">' . __('Activate') . '</a>';
+			$action = '<a href="#" id="off'. $html_safe['id'] . '" title="' . __('Activate this webhook') . '" class="off">' . __('Activate') . '</a>';
+		endif;
 
-	$html_safe['hook'] = esc_html( $desc['hook'] );
-	$html_safe['url'] = esc_html( $desc['url'] );
+		$nonce_delete = "<input type='hidden' id='delete-nonce-{$html_safe['id']}' name='delete-nonce-{$html_safe['id']}' value='" . wp_create_nonce( 'delete-webhook-' . $html_safe['id'] ) . "' />";
+		$delete = '<a href="#" id="delete'. $html_safe['id'] . '" title="' . __('Delete this webhook') . '" class="delete">' . __('Delete') . '</a>';
+		if( count( $desc['fields'] ) > 1 ) {
+			$desc['fields'] = array_map( 'esc_html', $desc['fields'] );
+			$fields = implode('</code>, <code>', $desc['fields'] );
+		} else
+			$fields = esc_html( $desc['fields'][0] );
 
-	echo "
+		$edit = '<a href="#TB_inline?inlineId=hookpress-webhook&height=330&width=500" id="edit'. $html_safe['id'] . '" title="' . __('Edit this webhook') . '" class="thickbox edit">' . __('Edit') . '</a>';
+
+		$activeornot = $desc['enabled'] ? 'active' : 'inactive';
+
+		$html_safe['hook'] = esc_html( $desc['hook'] );
+		$html_safe['url'] = esc_html( $desc['url'] );
+
+		echo "
 <tr id='$id' class='$activeornot'>
 	<td class='webhook-title'><strong>{$html_safe['hook']}</strong>
 	<div class='row-actions'>$nonce_action $nonce_delete<span class='edit'>$edit | <span class='delete'>$delete | </span><span class='action'>$action</span></div></td>
@@ -181,7 +193,7 @@ function hookpress_print_webhook_row( $id ) {
 function hookpress_print_webhooks_table() {
 	global $page;
 	$webhooks = null;
-#	$webhooks = get_option('hookpress_webhooks');
+	#	$webhooks = get_option('hookpress_webhooks');
 	$webhooks = hookpress_get_hooks( );
 ?>
 <table class="widefat" cellspacing="0" id="webhooks">
@@ -205,13 +217,13 @@ function hookpress_print_webhooks_table() {
 <?php
 
 	if ( !empty($webhooks) ) :
-	
-	foreach ( (array)$webhooks as $id => $desc) :
-		
-		if( !empty( $desc ) ):		
-			hookpress_print_webhook_row( $id );
-		endif;
-	endforeach;
+
+		foreach ( (array)$webhooks as $id => $desc) :
+
+			if( !empty( $desc ) ):
+				hookpress_print_webhook_row( $id );
+			endif;
+		endforeach;
 	endif;
 ?>
 	</tbody>
@@ -224,9 +236,9 @@ function hookpress_print_webhooks_table() {
 function hookpress_register_hooks() {
 	global $hookpress_callbacks, $hookpress_actions, $hookpress_filters;
 	$hookpress_callbacks = array();
-	
+
 	$all_hooks = hookpress_get_hooks( );
-	
+
 	if (!is_array( $all_hooks ) )
 		return;
 
@@ -240,8 +252,10 @@ function hookpress_register_hooks() {
 			$arg_count = 0;
 			if (isset($desc['type']) && $desc['type'] == 'filter')
 				$arg_count = count($hookpress_filters[$desc['hook']]);
-			else
-				$arg_count = count($hookpress_actions[$desc['hook']]);
+			else {
+				$hooks = apply_filters( 'hookpress_actions', $hookpress_actions );
+				$arg_count = count($hooks[$desc['hook']]);
+			}
 
 			add_filter($desc['hook'], $hookpress_callbacks[$id], HOOKPRESS_PRIORITY, $arg_count);
 		}
@@ -250,30 +264,37 @@ function hookpress_register_hooks() {
 
 function hookpress_generic_action($id,$args) {
 	global $hookpress_version, $wpdb, $hookpress_actions, $hookpress_filters, $wp_version;
-	
+
 	$webhooks = hookpress_get_hooks( );
 	$desc = $webhooks[$id];
 
 	do_action( 'hookpress_hook_fired', $desc );
 
 	$obj = array();
-	
+
 	// generate the expected argument names
 	if (isset($desc['type']) && $desc['type'] == 'filter')
-		$arg_names = $hookpress_filters[$desc['hook']];	
-	else
-		$arg_names = $hookpress_actions[$desc['hook']];
-	
+		$arg_names = $hookpress_filters[$desc['hook']];
+	else {
+		$hooks = apply_filters( 'hookpress_actions', $hookpress_actions );
+		$arg_names = $hooks[$desc['hook']];
+	}
+
 	foreach($args as $i => $arg) {
-		$newobj = array();
+		$newobj = apply_filters('hookpress_get_data', $obj, $arg_names[$i], $arg);
+
 		switch($arg_names[$i]) {
 			case 'POST':
 			case 'ATTACHMENT':
 				$newobj = get_post($arg,ARRAY_A);
 
-				if ($arg_names[$i] == 'POST')
+				if ($arg_names[$i] == 'POST') {
 					$newobj["post_url"] = get_permalink($newobj["ID"]);
-					
+
+					$meta = get_post_meta($newobj["ID"], '', true);
+					$newobj = array_merge($meta, $newobj);
+				}
+
 				if (wp_is_post_revision($arg)) {
 					$parent = get_post(wp_is_post_revision($arg));
 					foreach ($parent as $key => $val) {
@@ -281,7 +302,7 @@ function hookpress_generic_action($id,$args) {
 					}
 					$newobj["parent_post_url"] = get_permalink($newobj["parent_ID"]);
 				}
-				
+
 				break;
 			case 'COMMENT':
 				$arg = (int) $arg;
@@ -308,14 +329,14 @@ function hookpress_generic_action($id,$args) {
 		}
 		$obj = array_merge($obj,$newobj);
 	}
-	
+
 	// take only the fields we care about
 	$obj_to_post = array_intersect_key($obj,array_flip($desc['fields']));
 	$obj_to_post['hook'] = $desc['hook'];
-	
+
 	$user_agent = "HookPress/{$hookpress_version} (compatible; WordPress {$wp_version}; +http://mitcho.com/code/hookpress/)";
-	
+
 	$request = apply_filters( 'hookpress_request', array('user-agent' => $user_agent, 'body' => $obj_to_post, 'referer' => get_bloginfo('url')) );
-	
+
 	return wp_remote_post($desc['url'], $request);
 }

--- a/includes.php
+++ b/includes.php
@@ -97,7 +97,7 @@ if ($desc['type'] == 'filter')
 		
 	$fields = array();
 	foreach ($args as $arg) {
-		if (ereg('[A-Z]+',$arg))
+		if (preg_match('/[A-Z]+/',$arg))
 			$fields = array_merge($fields,hookpress_get_fields($arg));
 		else
 			$fields[] = $arg;

--- a/services.php
+++ b/services.php
@@ -10,7 +10,7 @@ function hookpress_ajax_get_fields() {
 	$fields = array();
 	if (is_array($args)) {
 		foreach ($args as $arg) {
-			if (ereg('[A-Z]+',$arg))
+			if (preg_match('/[A-Z]+/',$arg))
 				$fields = array_merge($fields,hookpress_get_fields($arg));
 			else
 				$fields[] = $arg;
@@ -46,7 +46,7 @@ function hookpress_ajax_add_fields() {
 			'type'=>$_POST['type'],
 			'hook'=>$_POST['hook'],
 			'enabled'=>$_POST['enabled'],
-			'fields'=>split(',',$_POST['fields'])
+			'fields'=>explode(',',$_POST['fields'])
 		);
 		hookpress_update_hook( $id, $edithook );
 
@@ -57,7 +57,7 @@ function hookpress_ajax_add_fields() {
 			'url'=>$_POST['url'],
 			'type'=>$_POST['type'],
 			'hook'=>$_POST['hook'],
-			'fields'=>split(',',$_POST['fields']),
+			'fields'=>explode(',',$_POST['fields']),
 			'enabled'=>true
 		);
 		$id = hookpress_add_hook($newhook);
@@ -76,7 +76,7 @@ function hookpress_ajax_set_enabled() {
 	$id = $_POST['id'];
 	$enabled = $_POST['enabled'];
 
-	$nonce_compare = ($enabled == 'true'?'activate-webhook-' . $id:'deactivate-webhook-' . $id ); 
+	$nonce_compare = ($enabled == 'true'?'activate-webhook-' . $id:'deactivate-webhook-' . $id );
 
 	if ( wp_verify_nonce( $nonce, $nonce_compare ) ) :
 

--- a/services.php
+++ b/services.php
@@ -2,8 +2,10 @@
 
 function hookpress_ajax_get_fields() {
 	global $wpdb, $hookpress_actions, $hookpress_filters;
-	if ($_POST['type'] == 'action')
-		$args = $hookpress_actions[$_POST['hook']];
+	if ($_POST['type'] == 'action') {
+		$hooks = apply_filters( 'hookpress_actions', $hookpress_actions );
+		$args = $hooks[$_POST['hook']];
+	}
 	if ($_POST['type'] == 'filter')
 		$args = $hookpress_filters[$_POST['hook']];
 
@@ -38,30 +40,30 @@ function hookpress_ajax_add_fields() {
 
 	if ( wp_verify_nonce( $nonce, $nonce_compare ) ) :
 
-	if( isset($_POST['id']) ){
+		if( isset($_POST['id']) ){
 
-		$id = (int) $_POST['id'];
-		$edithook = array(
-			'url'=>$_POST['url'],
-			'type'=>$_POST['type'],
-			'hook'=>$_POST['hook'],
-			'enabled'=>$_POST['enabled'],
-			'fields'=>explode(',',$_POST['fields'])
-		);
-		hookpress_update_hook( $id, $edithook );
+			$id = (int) $_POST['id'];
+			$edithook = array(
+				'url'=>$_POST['url'],
+				'type'=>$_POST['type'],
+				'hook'=>$_POST['hook'],
+				'enabled'=>$_POST['enabled'],
+				'fields'=>explode(',',$_POST['fields'])
+			);
+			hookpress_update_hook( $id, $edithook );
 
-	} else {
+		} else {
 
-		// register the new webhook
-		$newhook = array(
-			'url'=>$_POST['url'],
-			'type'=>$_POST['type'],
-			'hook'=>$_POST['hook'],
-			'fields'=>explode(',',$_POST['fields']),
-			'enabled'=>true
-		);
-		$id = hookpress_add_hook($newhook);
-	}
+			// register the new webhook
+			$newhook = array(
+				'url'=>$_POST['url'],
+				'type'=>$_POST['type'],
+				'hook'=>$_POST['hook'],
+				'fields'=>explode(',',$_POST['fields']),
+				'enabled'=>true
+			);
+			$id = hookpress_add_hook($newhook);
+		}
 
 	endif;
 
@@ -104,7 +106,7 @@ function hookpress_ajax_delete_hook() {
 	if ( !wp_verify_nonce( $nonce, $nonce_compare ) )
 		die("ERROR: invalid nonce");
 
-	 if (!$webhooks[$id])
+	if (!$webhooks[$id])
 		die("ERROR: no webhook found for that id");
 	hookpress_delete_hook( $id );
 	echo "ok";
@@ -119,8 +121,10 @@ function hookpress_ajax_edit_hook( $id ) {
 
 function hookpress_ajax_get_hooks() {
 	global $wpdb, $hookpress_actions, $hookpress_filters;
-	if ($_POST['type'] == 'action')
-		$hooks = array_keys($hookpress_actions);
+	if ($_POST['type'] == 'action') {
+		$hooks = apply_filters( 'hookpress_actions', $hookpress_actions );
+		$hooks = array_keys($hooks);
+	}
 	if ($_POST['type'] == 'filter')
 		$hooks = array_keys($hookpress_filters);
 

--- a/xaa
+++ b/xaa
@@ -1,0 +1,1 @@
+[A[D[A[Agit commit -m "PHP7 support - changed `ereg`->`preg_match` & `split`->`explode`" -m "If you have php7 installed it won't let you add webhook unless you make these changes. Changes are pretty forward `ereg` & `split` were introduced in php5 but now they are deprecated"


### PR DESCRIPTION
**Please merge it in your plugin a lot of our clients are complaining they can't get it work with hookpress.**

If you have php7 installed it won't let you add webhook unless you make these changes. Changes are pretty forward 'ereg' & 'split' were introduced in php5 but now they are deprecated, so used alternate functions.